### PR TITLE
Add support for multiarch container images (amd64/arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 # Dummy Dockerfile
-# check hoosk/build and hooks/push
+# check hooks/build and hooks/push

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:bullseye-20230227-slim
+FROM --platform=$TARGETPLATFORM debian:bullseye-20230227-slim
 
 ENV LANG=C.UTF-8 \
     USER=root HOME=/root \
     S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=10000
 
+ARG TARGETPLATFORM
 ARG S6_VERSION=v2.2.0.3
 
 COPY rootfs /
@@ -21,10 +22,11 @@ RUN apt_install \
 \
  # S6 Overlay
  && cd /tmp \
+ && if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then ARCH=amd64 ; elif [ "$TARGETPLATFORM" = "linux/arm64" ] ; then ARCH=aarch64 ; else exit 1 ; fi \
  # Download
- && curl -LSs https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-amd64.tar.gz -o s6-overlay-amd64.tar.gz \
+ && curl -LSs https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-$ARCH.tar.gz -o s6-overlay-$ARCH.tar.gz \
  # Install
- && tar -xzf s6-overlay-amd64.tar.gz -C / \
+ && tar -xzf s6-overlay-$ARCH.tar.gz -C / \
  # Clean
  && rm -rf /tmp/* \
  && apt_purge curl \

--- a/dbipc/Dockerfile
+++ b/dbipc/Dockerfile
@@ -1,5 +1,5 @@
 ARG TAGVER=
-FROM apluslms/service-base:base${TAGVER}
+FROM --platform=$TARGETPLATFORM apluslms/service-base:base${TAGVER}
 
 RUN mkdir -p /usr/share/man/man1/ /usr/share/man/man7/ \
  && apt_install \

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,5 @@
 ARG TAGVER=
-FROM apluslms/service-base:python3${TAGVER}
+FROM --platform=$TARGETPLATFORM apluslms/service-base:python3${TAGVER}
 
 COPY rootfs /
 RUN pip_install \

--- a/hooks/build
+++ b/hooks/build
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
 ver=$(echo "${DOCKER_TAG}"|cut -d- -f2)
 if [ "$ver" ]; then
     ver="-$ver"
@@ -16,17 +20,21 @@ for layer in $(grep -v "^\s*#" tags.txt); do
     if [ "$SOURCE_COMMIT" ]; then
         echo "############################################################"
         echo "### pulling latest image, so layer cache is update."
-        docker pull $DOCKER_REPO:$layer || true
+        docker pull $DOCKER_REPO:$layer || true
     fi
 
     echo "############################################################"
-    docker build --build-arg "TAGVER=$ver" -t $DOCKER_REPO:$layer "$layer/"
+    if [ "$ver" ]; then
+        docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg "TAGVER=$ver" \
+        -t $DOCKER_REPO:$layer \
+        -t $DOCKER_REPO:$layer$ver "$layer/"
+    else
+        docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg "TAGVER=$ver" \
+        -t $DOCKER_REPO:$layer "$layer/"
+    fi
     res=$?
     if [ $res -ne 0 ]; then
         echo "Building layer $layer returned $res" >&2
         exit $res
-    fi
-    if [ "$ver" ]; then
-        docker tag $DOCKER_REPO:$layer $DOCKER_REPO:$layer$ver
     fi
 done

--- a/hooks/push
+++ b/hooks/push
@@ -1,13 +1,3 @@
 #!/bin/sh
 
-ver=${DOCKER_TAG##*-}
-if [ "$ver" -a "$ver" = "$DOCKER_TAG" ]; then
-    ver=
-fi
-
-for layer in $(grep -v "^\s*#" tags.txt); do
-    docker push $DOCKER_REPO:$layer
-    if [ "$ver" ]; then
-        docker push $DOCKER_REPO:$layer-$ver
-    fi
-done
+# This hook is empty because the images were pushed to the registry in the build hook

--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -1,5 +1,5 @@
 ARG TAGVER=
-FROM apluslms/service-base:dbipc${TAGVER}
+FROM --platform=$TARGETPLATFORM apluslms/service-base:dbipc${TAGVER}
 
 COPY rootfs /
 


### PR DESCRIPTION
# Description

**What?**

Add support for automatic building of multi-architecture container images (amd64/arm64).

**Why?**

Container images built with support for the ARM architecture perform much better on Apple Silicon laptops.

**How?**

A custom build hook is used to build the images for amd64 and arm64.
The images are pushed to Docker Hub in the build hook.

Links about the docker buildx plugin for future reference:
- https://github.com/docker/buildx
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
- https://hub.docker.com/r/tonistiigi/binfmt

# Testing

I tested that Docker Hub Automated Builds work as expected.